### PR TITLE
Handle case of no buckets in a region

### DIFF
--- a/orgS3Inventory.py
+++ b/orgS3Inventory.py
@@ -104,6 +104,7 @@ def insertDict(region, bucketName):
 
 
 #Listing buckets and creating a dictonary of all buckets in an account with region as key
+regionDict = {}
 def listBuckets(s3):
     try:
         BucketName = s3.list_buckets() 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* If a region has no buckets at all, the script fails (see error below). This change fixes this by making sure `regionDict` is always defined.

```
Traceback (most recent call last):
  File "/Users/freiberg/workspace/one-offs/amazon-orglevels3inventorycontrolplane/orgS3Inventory.py", line 215, in <module>
    main()
    ~~~~^^
  File "/Users/freiberg/workspace/one-offs/amazon-orglevels3inventorycontrolplane/orgS3Inventory.py", line 211, in main
    createDestBucketAndSetPolicies(destinationAccountId)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/freiberg/workspace/one-offs/amazon-orglevels3inventorycontrolplane/orgS3Inventory.py", line 162, in createDestBucketAndSetPolicies
    accountDict = listBuckets(s3BucketClient)
  File "/Users/freiberg/workspace/one-offs/amazon-orglevels3inventorycontrolplane/orgS3Inventory.py", line 118, in listBuckets
    return regionDict
           ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'regionDict' where it is not associated with a value
``` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
